### PR TITLE
CI: Deploy all tagged commits to Github Package Registry

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,33 @@
+name: Deploy
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup JDK
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+
+      - name: Validate Gradle wrapper
+        uses: gradle/wrapper-validation-action@ccb4328a959376b642e027874838f60f8e596de3
+
+      - name: Publish package
+        uses: gradle/gradle-build-action@749f47bda3e44aa060e82d7b3ef7e40d953bd629
+        with:
+          arguments: publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: Build & Test
+
+on:
+  pull_request:
+    branches:
+      - '*'
+  push:
+    branches:
+      - '*'
+
+jobs:
+  build:
+    name: Build & Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup JDK
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+
+      - name: Run Tests
+        run: ./gradlew test --info
+

--- a/build.gradle
+++ b/build.gradle
@@ -31,19 +31,19 @@ publishing {
         mavenJava(MavenPublication) {
             from components.java
 
-            groupId = 'com.orgzly'
+            groupId = 'com.orgzlyrevived'
             artifactId = 'org-java'
             version = VERSION_NAME
 
             pom {
                 name = 'org-java'
                 description = 'Org files parser and generator'
-                url = 'https://github.com/orgzly/org-java'
+                url = 'https://github.com/orgzly-revived/org-java'
 
                 scm {
-                    url = "http://github.com/orgzly/org-java"
-                    connection = "scm:git:http://github.com/orgzly/org-java.git"
-                    developerConnection = "scm:git:git@github.com:orgzly/org-java.git"
+                    url = "http://github.com/orgzly-revived/org-java"
+                    connection = "scm:git:http://github.com/orgzly-revived/org-java.git"
+                    developerConnection = "scm:git:git@github.com:orgzly-revived/org-java.git"
                 }
 
                 licenses {
@@ -66,19 +66,16 @@ publishing {
 
     repositories {
         maven {
-            def releasesRepoUrl = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
-            def snapshotsRepoUrl = 'https://oss.sonatype.org/content/repositories/snapshots/'
-
-            url = isReleaseBuild() ? releasesRepoUrl : snapshotsRepoUrl
-
+            name = "GitHubPackages"
+            url = "https://maven.pkg.github.com/" + System.getenv("GITHUB_REPOSITORY")
             credentials {
-                username = ossrhUsername
-                password = ossrhPassword
+                username = System.getenv("GITHUB_ACTOR")
+                password = System.getenv("GITHUB_TOKEN")
             }
         }
     }
 }
 
-signing {
-    sign publishing.publications.mavenJava
-}
+//signing {
+//    sign publishing.publications.mavenJava
+//}


### PR DESCRIPTION
- New Github Action Workflow to test the project (inspired by the travis config found in the old org-java repo)
- New Github Action Workflow to deploy the project's artifact 
- Adapted Gradle config to use Github Package registry as target for the deployment (instead of oss.sonatype.org). 