### PR TITLE
Tell Jitpack.io to use Java 11

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk11


### PR DESCRIPTION
Let's try letting Jitpack.io build this for us. Jitpack is one of the artifact sources that Fdroid trusts.

https://stackoverflow.com/questions/68609683/android-gradle-plugin-requires-java-11-to-run-you-are-currently-using-java-1-8/68756946#68756946